### PR TITLE
Add Makefile.in for new file structure

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1,0 +1,23 @@
+VPATH=%VPATH%
+
+RUSTC ?= rustc
+RUSTFLAGS ?=
+
+RUST_SRC = $(shell find $(VPATH)/src -type f -name '*.rs')
+
+.PHONY: all
+all: libcocoa.dummy
+
+libcocoa.dummy: src/lib.rs $(RUST_SRC)
+	$(RUSTC) $(RUSTFLAGS) $< --out-dir .
+	touch $@
+
+cocoa-test: src/lib.rs $(RUST_SRC)
+	$(RUSTC) $(RUSTFLAGS) $< -o $@ --test
+
+check: cocoa-test
+	./cocoa-test
+
+.PHONY: clean
+clean:
+	rm -f cocoa-test *.a *.o *.so *.dylib *.dll *.dummy

--- a/Makefile.in
+++ b/Makefile.in
@@ -20,4 +20,4 @@ check: cocoa-test
 
 .PHONY: clean
 clean:
-	rm -f cocoa-test *.a *.o *.so *.dylib *.dll *.dummy
+	rm -f cocoa-test *.a *.o *.so *.dylib *.rlib *.dll *.dummy


### PR DESCRIPTION
Looks like someone forgot the Makefile.in :)

Test results:

make
make cocoa-test

rust-cocoa dave$ ./cocoa-test

running 2 tests
test base::test::test_custom_obj ... ok
test base::test::test_nsapp ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured