### PR TITLE
Cargo compatibility (feature = "arch_64" flag)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,10 @@ name = "cocoa"
 version = "0.1.1"
 authors = ["The Servo Project Developers"]
 
+[features]
+
+arch_64 = []
+
 [lib]
 
 name = "cocoa"

--- a/src/appkit.rs
+++ b/src/appkit.rs
@@ -261,34 +261,34 @@ pub enum NSEventType {
 
 #[repr(u64)]
 pub enum NSEventMask {
-    NSLeftMouseDownMask         = 1 << NSLeftMouseDown as uint,
-    NSLeftMouseUpMask           = 1 << NSLeftMouseUp as uint,
-    NSRightMouseDownMask        = 1 << NSRightMouseDown as uint,
-    NSRightMouseUpMask          = 1 << NSRightMouseUp as uint,
-    NSMouseMovedMask            = 1 << NSMouseMoved as uint,
-    NSLeftMouseDraggedMask      = 1 << NSLeftMouseDragged as uint,
-    NSRightMouseDraggedMask     = 1 << NSRightMouseDragged as uint,
-    NSMouseEnteredMask          = 1 << NSMouseEntered as uint,
-    NSMouseExitedMask           = 1 << NSMouseExited as uint,
-    NSKeyDownMask               = 1 << NSKeyDown as uint,
-    NSKeyUpMask                 = 1 << NSKeyUp as uint,
-    NSFlagsChangedMask          = 1 << NSFlagsChanged as uint,
-    NSAppKitDefinedMask         = 1 << NSAppKitDefined as uint,
-    NSSystemDefinedMask         = 1 << NSSystemDefined as uint,
-    NSAPplicationDefinedMask    = 1 << NSApplicationDefined as uint,
-    NSPeriodicMask              = 1 << NSPeriodic as uint,
-    NSCursorUpdateMask          = 1 << NSCursorUpdate as uint,
-    NSScrollWheelMask           = 1 << NSScrollWheel as uint,
-    NSTabletPointMask           = 1 << NSTabletPoint as uint,
-    NSTabletProximityMask       = 1 << NSTabletProximity as uint,
-    NSOtherMouseDownMask        = 1 << NSOtherMouseDown as uint,
-    NSOtherMouseUpMask          = 1 << NSOtherMouseUp as uint,
-    NSOtherMouseDraggedMask     = 1 << NSOtherMouseDragged as uint,
-    NSEventMaskgesture          = 1 << NSEventTypeGesture as uint,
-    NSEventMaskSwipe            = 1 << NSEventTypeSwipe as uint,
-    NSEventMaskRotate           = 1 << NSEventTypeRotate as uint,
-    NSEventMaskBeginGesture     = 1 << NSEventTypeBeginGesture as uint,
-    NSEventMaskEndGesture       = 1 << NSEventTypeEndGesture as uint,
+    NSLeftMouseDownMask         = 1 << NSLeftMouseDown as u32,
+    NSLeftMouseUpMask           = 1 << NSLeftMouseUp as u32,
+    NSRightMouseDownMask        = 1 << NSRightMouseDown as u32,
+    NSRightMouseUpMask          = 1 << NSRightMouseUp as u32,
+    NSMouseMovedMask            = 1 << NSMouseMoved as u32,
+    NSLeftMouseDraggedMask      = 1 << NSLeftMouseDragged as u32,
+    NSRightMouseDraggedMask     = 1 << NSRightMouseDragged as u32,
+    NSMouseEnteredMask          = 1 << NSMouseEntered as u32,
+    NSMouseExitedMask           = 1 << NSMouseExited as u32,
+    NSKeyDownMask               = 1 << NSKeyDown as u32,
+    NSKeyUpMask                 = 1 << NSKeyUp as u32,
+    NSFlagsChangedMask          = 1 << NSFlagsChanged as u32,
+    NSAppKitDefinedMask         = 1 << NSAppKitDefined as u32,
+    NSSystemDefinedMask         = 1 << NSSystemDefined as u32,
+    NSAPplicationDefinedMask    = 1 << NSApplicationDefined as u32,
+    NSPeriodicMask              = 1 << NSPeriodic as u32,
+    NSCursorUpdateMask          = 1 << NSCursorUpdate as u32,
+    NSScrollWheelMask           = 1 << NSScrollWheel as u32,
+    NSTabletPointMask           = 1 << NSTabletPoint as u32,
+    NSTabletProximityMask       = 1 << NSTabletProximity as u32,
+    NSOtherMouseDownMask        = 1 << NSOtherMouseDown as u32,
+    NSOtherMouseUpMask          = 1 << NSOtherMouseUp as u32,
+    NSOtherMouseDraggedMask     = 1 << NSOtherMouseDragged as u32,
+    NSEventMaskgesture          = 1 << NSEventTypeGesture as u32,
+    NSEventMaskSwipe            = 1 << NSEventTypeSwipe as u32,
+    NSEventMaskRotate           = 1 << NSEventTypeRotate as u32,
+    NSEventMaskBeginGesture     = 1 << NSEventTypeBeginGesture as u32,
+    NSEventMaskEndGesture       = 1 << NSEventTypeEndGesture as u32,
     NSAnyEventMask              = 0xffffffff,
 }
 
@@ -898,11 +898,11 @@ pub trait NSOpenGLPixelFormat {
         msg_send()(class("NSOpenGLPixelFormat"), selector("alloc"))
     }
 
-    unsafe fn initWithAttributes_(self, attributes: &[uint]) -> id;
+    unsafe fn initWithAttributes_(self, attributes: &[u32]) -> id;
 }
 
 impl NSOpenGLPixelFormat for id {
-    unsafe fn initWithAttributes_(self, attributes: &[uint]) -> id {
+    unsafe fn initWithAttributes_(self, attributes: &[u32]) -> id {
         msg_send()(self, selector("initWithAttributes:"), attributes)
     }
 }

--- a/src/appkit.rs
+++ b/src/appkit.rs
@@ -22,9 +22,9 @@ pub use self::NSEventType::*;
 pub use self::NSEventMask::*;
 pub use self::NSEventModifierFlags::*;
 
-#[cfg(target_word_size = "32")]
+#[cfg(not(feature = "arch_64"))]
 pub type CGFloat = f32;
-#[cfg(target_word_size = "64")]
+#[cfg(feature = "arch_64")]
 pub type CGFloat = f64;
 
 pub type GLint = libc::int32_t;

--- a/src/base.rs
+++ b/src/base.rs
@@ -7,10 +7,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use libc::{c_long, c_ulong, c_char};
+use libc::c_char;
 use libc;
 
-use std::c_str::ToCStr;
+use std::ffi::CString;
 use std::mem;
 
 pub type Class = libc::intptr_t;
@@ -64,7 +64,7 @@ pub unsafe fn msg_send_stret<T>() -> extern fn(theReceiver: id, theSelector: SEL
 /// A convenience method to convert the name of a class to the class object itself.
 #[inline]
 pub fn class(name: &str) -> id {
-    let name_c_str = name.to_c_str();
+    let name_c_str = CString::from_slice(name.as_bytes());
     unsafe {
         objc_getClass(name_c_str.as_ptr())
     }
@@ -73,7 +73,7 @@ pub fn class(name: &str) -> id {
 /// A convenience method to convert the name of a selector to the selector object.
 #[inline]
 pub fn selector(name: &str) -> SEL {
-    let name_c_str = name.to_c_str();
+    let name_c_str = CString::from_slice(name.as_bytes());
     unsafe {
         sel_registerName(name_c_str.as_ptr())
     }
@@ -82,7 +82,7 @@ pub fn selector(name: &str) -> SEL {
 #[cfg(test)]
 mod test {
     use libc;
-    use std::c_str::ToCStr;
+    use std::ffi::CString;
     use super::*;
 
     #[test]
@@ -100,13 +100,13 @@ mod test {
         }
 
         let ns_object = class("NSObject");
-        let name_c_str = "MyObject".to_c_str();
+        let name_c_str = CString::from_slice("MyObject".as_bytes());
         let my_object = unsafe {
             objc_allocateClassPair(ns_object, name_c_str.as_ptr(), 0 as libc::size_t)
         };
 
         let doSomething = selector("doSomething");
-        let types_c_str = "@@:".to_c_str();
+        let types_c_str = CString::from_slice("@@:".as_bytes());
         unsafe {
             let _ = class_addMethod(my_object, doSomething, MyObject_doSomething,
                                     types_c_str.as_ptr());

--- a/src/base.rs
+++ b/src/base.rs
@@ -20,14 +20,14 @@ pub type SEL = libc::intptr_t;
 #[allow(non_camel_case_types)]
 pub type id = libc::intptr_t;
 
-#[cfg(target_word_size = "32")]
+#[cfg(not(feature = "arch_64"))]
 pub type NSInteger = libc::c_int;
-#[cfg(target_word_size = "32")]
+#[cfg(not(feature = "arch_64"))]
 pub type NSUInteger = libc::c_uint;
 
-#[cfg(target_word_size = "64")]
+#[cfg(feature = "arch_64")]
 pub type NSInteger = libc::c_long;
-#[cfg(target_word_size = "64")]
+#[cfg(feature = "arch_64")]
 pub type NSUInteger = libc::c_ulong;
 
 #[allow(non_upper_case_globals)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,8 +13,6 @@
 #![comment = "The Servo Parallel Browser Project"]
 #![license = "MIT"]
 
-#![feature(globs)]
-
 #![allow(non_snake_case)]
 
 extern crate libc;
@@ -23,4 +21,3 @@ extern crate libc;
 pub mod appkit;
 #[cfg(target_os="macos")]
 pub mod base;
-


### PR DESCRIPTION
This depends on the other PR, #53 

* Removes `cfg(target_word_size = "32")` and `cfg(target_word_size = "64")`
* Makes 32 bit the default
* Adds `"arch_64"` feature to `Cargo.toml` which "upgrades" from 32 bit to 64 bit