### PR TITLE
Cargo compatibility (target_pointer_width)

### DIFF
--- a/src/appkit.rs
+++ b/src/appkit.rs
@@ -22,9 +22,9 @@ pub use self::NSEventType::*;
 pub use self::NSEventMask::*;
 pub use self::NSEventModifierFlags::*;
 
-#[cfg(target_word_size = "32")]
+#[cfg(target_pointer_width = "32")]
 pub type CGFloat = f32;
-#[cfg(target_word_size = "64")]
+#[cfg(target_pointer_width = "64")]
 pub type CGFloat = f64;
 
 pub type GLint = libc::int32_t;

--- a/src/base.rs
+++ b/src/base.rs
@@ -20,14 +20,14 @@ pub type SEL = libc::intptr_t;
 #[allow(non_camel_case_types)]
 pub type id = libc::intptr_t;
 
-#[cfg(target_word_size = "32")]
+#[cfg(target_pointer_width = "32")]
 pub type NSInteger = libc::c_int;
-#[cfg(target_word_size = "32")]
+#[cfg(target_pointer_width = "32")]
 pub type NSUInteger = libc::c_uint;
 
-#[cfg(target_word_size = "64")]
+#[cfg(target_pointer_width = "64")]
 pub type NSInteger = libc::c_long;
-#[cfg(target_word_size = "64")]
+#[cfg(target_pointer_width = "64")]
 pub type NSUInteger = libc::c_ulong;
 
 #[allow(non_upper_case_globals)]


### PR DESCRIPTION
Replaces #54 

This simply replaces `#[cfg(target_word_size = "64")]` with `#[cfg(not(target_word_size = "32"))]`, which solves the problem of Cargo not selecting a target word size.