### PR TITLE
Update to Rust 1.0 Alpha and Rust Nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,6 @@ license = "MIT"
 [lib]
 name = "cocoa"
 crate-type = ["rlib"]
+
+[dependencies]
+bitflags = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,9 @@
 [package]
-
 name = "cocoa"
 version = "0.1.1"
 authors = ["The Servo Project Developers"]
+license = "MIT"
 
 [lib]
-
 name = "cocoa"
 crate-type = ["rlib"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,8 @@
 
 #![allow(missing_copy_implementations, non_snake_case, unstable)]
 
+#[macro_use]
+extern crate bitflags;
 extern crate libc;
 
 #[cfg(target_os="macos")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,10 +10,7 @@
 #![crate_name = "cocoa"]
 #![crate_type = "rlib"]
 
-#![comment = "The Servo Parallel Browser Project"]
-#![license = "MIT"]
-
-#![allow(non_snake_case)]
+#![allow(missing_copy_implementations, non_snake_case, unstable)]
 
 extern crate libc;
 


### PR DESCRIPTION
Hello,


The pull request

1. eliminates warnings when compiling with Rust 1.0 Alpha and
2. eliminates an error when compiling with Rust Nightly.

The latter is due to the absence of `bitflags!` in the standard library; the macro has been moved into a [separate crate](https://crates.io/crates/bitflags).


Regards,
Ivan