### PR TITLE
Fixes for compiling on recent nightly (2015-02-04) without warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,8 @@
 #![crate_name = "cocoa"]
 #![crate_type = "rlib"]
 
-#![allow(missing_copy_implementations, non_snake_case, unstable)]
+#![allow(missing_copy_implementations, non_snake_case)]
+#![feature(std_misc, hash)]
 
 #[macro_use]
 extern crate bitflags;


### PR DESCRIPTION
Silenced warnings by adding `std_misc` and `hash` features and removing the `unstable` warning allowance.