### PR TITLE
Use `objc_msgSend_fpret` for `backingStoreFactor`.

### DIFF
--- a/src/appkit.rs
+++ b/src/appkit.rs
@@ -9,7 +9,7 @@
 
 #![allow(non_upper_case_globals)]
 
-use base::{id, msg_send, msg_send_stret, class, selector};
+use base::{id, msg_send, msg_send_fpret, msg_send_stret, class, selector};
 use base::{BOOL, SEL, NSInteger, NSUInteger};
 use libc;
 
@@ -1054,7 +1054,7 @@ impl NSWindow for id {
     // Converting Coordinates
 
     unsafe fn backingScaleFactor(self) -> CGFloat {
-        msg_send()(self, selector("backingScaleFactor"))
+        msg_send_fpret()(self, selector("backingScaleFactor"))
     }
 
     unsafe fn backingAlignedRect_options_(self, rect: NSRect, options: NSAlignmentOptions) -> NSRect {

--- a/src/base.rs
+++ b/src/base.rs
@@ -159,7 +159,7 @@ extern {
     pub fn objc_loadWeak(location: *mut id) -> id;
     pub fn objc_storeWeak(location: *mut id, obj: id) -> id;
     pub fn objc_msgSend(target: id, selector: SEL, ...) -> id;
-    pub fn objc_msgSend_ftret(target: id, selector: SEL, ...) -> libc::c_double;
+    pub fn objc_msgSend_fpret(target: id, selector: SEL, ...) -> libc::c_double;
     pub fn objc_msgSend_stret(target: id, selector: SEL, ...);
     pub fn objc_msgSendSuper(sup: *mut objc_super, op: SEL, ...) -> id;
     pub fn objc_msgSendSuper_stret(sup: *mut objc_super, op: SEL, ...);
@@ -240,6 +240,11 @@ extern {
 /// ```
 pub unsafe fn msg_send<T>() -> extern fn(target: id, selector: SEL, ...) -> T {
     mem::transmute(objc_msgSend)
+}
+
+/// Returns an Objective-C message send function that returns a floating-point type.
+pub unsafe fn msg_send_fpret<T>() -> extern fn(target: id, selector: SEL, ...) -> T {
+    mem::transmute(objc_msgSend_fpret)
 }
 
 /// Returns an Objective-C message send function that returns a type `T`, where `T` is a struct


### PR DESCRIPTION
This mistake led to a bizarre chain reaction in Servo that ultimately
led to a hang only when optimization was enabled.

r? @bjz 