### PR TITLE
Fix build error

### DIFF
--- a/src/appkit.rs
+++ b/src/appkit.rs
@@ -19,8 +19,6 @@ pub use self::NSBackingStoreType::*;
 pub use self::NSOpenGLPixelFormatAttribute::*;
 pub use self::NSOpenGLPFAOpenGLProfiles::*;
 pub use self::NSEventType::*;
-pub use self::NSEventMask::*;
-pub use self::NSEventModifierFlags::*;
 
 use std::ffi::CString;
 

--- a/src/appkit.rs
+++ b/src/appkit.rs
@@ -1217,7 +1217,7 @@ impl NSString for id {
     }
 
     unsafe fn init_str(self, string: &str) -> id {
-        let cstring = CString::from_slice(string.as_bytes());
+        let cstring = CString::new(string).unwrap();
         self.initWithUTF8String_(cstring.as_ptr())
     }
 

--- a/src/base.rs
+++ b/src/base.rs
@@ -256,7 +256,7 @@ pub unsafe fn msg_send_stret<T>() -> extern fn(target: id, selector: SEL, ...) -
 /// A convenience method to convert the name of a class to the class object itself.
 #[inline]
 pub fn class(name: &str) -> Class {
-    let name_c_str = ffi::CString::from_slice(name.as_bytes());
+    let name_c_str = ffi::CString::new(name).unwrap();
     unsafe {
         objc_getClass(name_c_str.as_ptr())
     }
@@ -265,7 +265,7 @@ pub fn class(name: &str) -> Class {
 /// A convenience method to convert the name of a selector to the selector object.
 #[inline]
 pub fn selector(name: &str) -> SEL {
-    let name_c_str = ffi::CString::from_slice(name.as_bytes());
+    let name_c_str = ffi::CString::new(name).unwrap();
     unsafe {
         sel_registerName(name_c_str.as_ptr())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 #![crate_type = "rlib"]
 
 #![allow(missing_copy_implementations, non_snake_case)]
-#![feature(std_misc, hash)]
+#![feature(std_misc)]
 
 #[macro_use]
 extern crate bitflags;


### PR DESCRIPTION
1. `NSEventMask`, `NSEventModifierFlags` are not module, so commands like below is not valid anymore.

    ```
    pub use self::NSEventMask::*;
    pub use self::NSEventModifierFlags::*;
    ```
1.  You don't need `#![feature(hash)]` anymore.
2.  `CString::from_slice` is deprecated now.