### PR TITLE
Remove unused std_misc feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,8 +10,7 @@
 #![crate_name = "cocoa"]
 #![crate_type = "rlib"]
 
-#![allow(missing_copy_implementations, non_snake_case)]
-#![feature(std_misc)]
+#![allow(non_snake_case)]
 
 #[macro_use]
 extern crate bitflags;


### PR DESCRIPTION
The `std_misc` feature is unused, and removing it allows this crate to build on stable rust.

Also removed the unnecessary `allow(missing_copy_implementations)` since it's allowed by default.