### PR TITLE
Fix overflow in NSTouchPhase definition

### DIFF
--- a/src/appkit.rs
+++ b/src/appkit.rs
@@ -1355,7 +1355,7 @@ bitflags! {
         const NSTouchPhaseTouching      = NSTouchPhaseBegan.bits
                                         | NSTouchPhaseMoved.bits
                                         | NSTouchPhaseStationary.bits,
-        const NSTouchPhaseAny           = 0 - 1, // NSUIntegerMax
+        const NSTouchPhaseAny           = !0, // NSUIntegerMax
     }
 }
 


### PR DESCRIPTION
`NSTouchPhase` was subtracting 1 from 0 and overflowing NSUInteger, which isn't a nice thing to do anymore; it causes the error:
```
src/appkit.rs:1358:43: 1358:48 error: attempted to sub with overflow
src/appkit.rs:1358         const NSTouchPhaseAny           = 0 - 1, // NSUIntegerMax
                                                             ^~~~~
```

We can switch it from -1 to !0 to fix this.